### PR TITLE
Update SA5Firmata_ir.ino

### DIFF
--- a/firmata/SA5Firmata_ir.ino
+++ b/firmata/SA5Firmata_ir.ino
@@ -933,18 +933,18 @@ void sysexCallback(byte command, byte argc, byte *argv)
   //Code from wiring.c, function init
   // set timer 2 prescale factor to 64
   #if defined(TCCR2) && defined(CS22)
-    TCCR2 |= (1 << CS22);  // sbi(TCCR2, CS22);  <-- old version of the code dosen't supported in new version of C++
+    TCCR2 |= (1 << CS22);  // sbi(TCCR2, CS22);  <-- old version of the code dosen't supported
   #elif defined(TCCR2B) && defined(CS22)
-    TCCR2B |= (1 << CS22); // sbi(TCCR2B, CS22); <-- old version of the code dosen't supported in new version of C++
+    TCCR2B |= (1 << CS22); // sbi(TCCR2B, CS22); <-- old version of the code dosen't supported
     //#else
     // Timer 2 not finished (may not be present on this CPU)
   #endif
 
   // configure timer 2 for phase correct pwm (8-bit)
   #if defined(TCCR2) && defined(WGM20)
-    TCCR2 |= (1 << WGM20); // sbi(TCCR2, WGM20); <-- old version of the code dosen't supported in new version of C++
+    TCCR2 |= (1 << WGM20); // sbi(TCCR2, WGM20); <-- old version of the code dosen't supported
   #elif defined(TCCR2A) && defined(WGM20)
-    TCCR2A |= (1 << WGM20); // sbi(TCCR2A, WGM20); <-- old version of the code dosen't supported in new version of C++
+    TCCR2A |= (1 << WGM20); // sbi(TCCR2A, WGM20); <-- old version of the code dosen't supported
     //#else
     // Timer 2 not finished (may not be present on this CPU)
   #endif

--- a/firmata/SA5Firmata_ir.ino
+++ b/firmata/SA5Firmata_ir.ino
@@ -933,18 +933,18 @@ void sysexCallback(byte command, byte argc, byte *argv)
   //Code from wiring.c, function init
   // set timer 2 prescale factor to 64
   #if defined(TCCR2) && defined(CS22)
-    sbi(TCCR2, CS22);
+    TCCR2 |= (1 << CS22);  // sbi(TCCR2, CS22);  <-- old version of the code dosen't supported in new version of C++
   #elif defined(TCCR2B) && defined(CS22)
-    sbi(TCCR2B, CS22);
+    TCCR2B |= (1 << CS22); // sbi(TCCR2B, CS22); <-- old version of the code dosen't supported in new version of C++
     //#else
     // Timer 2 not finished (may not be present on this CPU)
   #endif
 
   // configure timer 2 for phase correct pwm (8-bit)
   #if defined(TCCR2) && defined(WGM20)
-    sbi(TCCR2, WGM20);
+    TCCR2 |= (1 << WGM20); // sbi(TCCR2, WGM20); <-- old version of the code dosen't supported in new version of C++
   #elif defined(TCCR2A) && defined(WGM20)
-    sbi(TCCR2A, WGM20);
+    TCCR2A |= (1 << WGM20); // sbi(TCCR2A, WGM20); <-- old version of the code dosen't supported in new version of C++
     //#else
     // Timer 2 not finished (may not be present on this CPU)
   #endif


### PR DESCRIPTION
Fix code compilation bug (image attached).

Update to lines of code 936, 938, 945 and 947. The SBI "Set Bit Instruction", a macro or function used to set (or turn on) a specific bit in a register or variable. And it has been discontinued in a library.
![error](https://github.com/jguille2/SA5/assets/170818651/a8cc51dc-1d45-41ab-95cc-49890830c03b)
